### PR TITLE
Fix CameraService.h error during compilation

### DIFF
--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+soong_namespace {
+}
+
 cc_binary {
     name: "cameraserver",
 

--- a/camera/cameraserver/Android.bp
+++ b/camera/cameraserver/Android.bp
@@ -18,7 +18,7 @@ cc_binary {
     srcs: ["main_cameraserver.cpp"],
 
     shared_libs: [
-        "libcameraservice",
+        "//frameworks/av/services/camera/libcameraservice:libcameraservice",
         "liblog",
         "libutils",
         "libui",

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+soong_namespace {
+}
+
 //
 // libcameraservice
 //


### PR DESCRIPTION
frameworks/av/camera/cameraserver/main_cameraserver.cpp:20:10: fatal error: 'CameraService.h' file not found.